### PR TITLE
Loosen version requirements on FastApi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.6"
 aiojobs = "^0.2.2"
 pydantic = "^1.5.1"
 starlette = "^0.13.2"
-fastapi = "^0.55.1"
+fastapi = "^0.55"
 
 [tool.poetry.dev-dependencies]
 uvicorn = "^0.8.6"


### PR DESCRIPTION
This lib is (most likely) needlessly restricted to 0.55.x rather than 0.55+ and this gets rid of that restriction making it compatible with 0.56, 57, 58 etc

This PR closes #9 

May I add this is blocking adoption for anyone not using specifically version 0.55 of fastapi on poetry (and potentially more) as there is no simple way to override version solving issues. For now I have vendored it and await for a version bump.

Thanks for the lib!