### PR TITLE
Allow fastapi greater than 0.55

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,7 @@ exclude = ["example1.py", "example2.py"]
 [tool.poetry.dependencies]
 python = "^3.6"
 aiojobs = "^0.2.2"
-pydantic = "^1.5.1"
-starlette = "^0.13.2"
-fastapi = "^0.55"
+fastapi = ">0.55"
 
 [tool.poetry.dev-dependencies]
 uvicorn = "^0.8.6"


### PR DESCRIPTION
Also, `pydantic` and `starlette` are dependencies of `fastapi` already, and so we can remove them from our deps.

Fixes #9 more better than #10 .