### PR TITLE
fix(openapi): no more conflicts in openapi components which leads to missing models in openapi.json or openapi generation error in rare cases

### DIFF
--- a/fastapi_jsonrpc/__init__.py
+++ b/fastapi_jsonrpc/__init__.py
@@ -92,6 +92,7 @@ def component_name(name: str, module: str = None):
     """OpenAPI components must be unique by name"""
     def decorator(obj):
         obj.__name__ = name
+        obj.__qualname__ = name
         if module is not None:
             obj.__module__ = module  # see: pydantic.schema.get_long_model_name
         key = (obj.__name__, obj.__module__)


### PR DESCRIPTION
pydantic.schema.get_long_model_name use __qualname__ to solve conflicts, if we do not respect this values generated model map (by get_model_name_map) can replace some models and this is root of problem