### PR TITLE
tests: Support fastapi 0.64.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -166,21 +166,21 @@ wrapt = "*"
 
 [[package]]
 name = "fastapi"
-version = "0.63.0"
+version = "0.66.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pydantic = ">=1.0.0,<2.0.0"
-starlette = "0.13.6"
+pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
+starlette = "0.14.2"
 
 [package.extras]
-all = ["requests (>=2.24.0,<3.0.0)", "aiofiles (>=0.5.0,<0.6.0)", "jinja2 (>=2.11.2,<3.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<2.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "graphene (>=2.1.8,<3.0.0)", "ujson (>=3.0.0,<4.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn[standard] (>=0.12.0,<0.14.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)"]
+all = ["requests (>=2.24.0,<3.0.0)", "aiofiles (>=0.5.0,<0.6.0)", "jinja2 (>=2.11.2,<3.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<2.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "graphene (>=2.1.8,<3.0.0)", "ujson (>=4.0.1,<5.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn[standard] (>=0.12.0,<0.14.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)"]
 dev = ["python-jose[cryptography] (>=3.1.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn[standard] (>=0.12.0,<0.14.0)", "graphene (>=2.1.8,<3.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=6.1.4,<7.0.0)", "markdown-include (>=0.5.1,<0.6.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.2.0)", "typer-cli (>=0.0.9,<0.0.10)", "pyyaml (>=5.3.1,<6.0.0)"]
-test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<0.15.0)", "mypy (==0.790)", "flake8 (>=3.8.3,<4.0.0)", "black (==20.8b1)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.15.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.4.0)", "orjson (>=3.2.1,<4.0.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "aiofiles (>=0.5.0,<0.6.0)", "flask (>=1.1.2,<2.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=7.1.9,<8.0.0)", "markdown-include (>=0.6.0,<0.7.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.2.0)", "typer-cli (>=0.0.12,<0.0.13)", "pyyaml (>=5.3.1,<6.0.0)"]
+test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<0.15.0)", "mypy (==0.812)", "flake8 (>=3.8.3,<4.0.0)", "black (==20.8b1)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.15.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<1.4.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.4.0)", "orjson (>=3.2.1,<4.0.0)", "ujson (>=4.0.1,<5.0.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "aiofiles (>=0.5.0,<0.6.0)", "flask (>=1.1.2,<2.0.0)"]
 
 [[package]]
 name = "h11"
@@ -481,14 +481,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "starlette"
-version = "0.13.6"
+version = "0.14.2"
 description = "The little ASGI library that shines."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-full = ["aiofiles", "graphene", "itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "ujson"]
+full = ["aiofiles", "graphene", "itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
 
 [[package]]
 name = "toml"
@@ -572,7 +572,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "90db5b7f3374a512c90cce6fe2b1728b2eaa712eec8084bb18e2e3e7df804e6a"
+content-hash = "54462b13368f2cb69443dc0b617097cfe182100fd64af9b3f4dd27b4b2b5348b"
 
 [metadata.files]
 aiohttp = [
@@ -682,8 +682,8 @@ fake-winreg = [
     {file = "fake_winreg-1.5.6.tar.gz", hash = "sha256:4e4abbede859abcd8cc8e997fe86078c7359d62e42e41d785547e1a63cedd69f"},
 ]
 fastapi = [
-    {file = "fastapi-0.63.0-py3-none-any.whl", hash = "sha256:98d8ea9591d8512fdadf255d2a8fa56515cdd8624dca4af369da73727409508e"},
-    {file = "fastapi-0.63.0.tar.gz", hash = "sha256:63c4592f5ef3edf30afa9a44fa7c6b7ccb20e0d3f68cd9eba07b44d552058dcb"},
+    {file = "fastapi-0.66.0-py3-none-any.whl", hash = "sha256:85d8aee8c3c46171f4cb7bb3651425a42c07cb9183345d100ef55d88ca2ce15f"},
+    {file = "fastapi-0.66.0.tar.gz", hash = "sha256:6ea4225448786f3d6fae737713789f87631a7455f65580de0a4a2e50471060d9"},
 ]
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
@@ -873,8 +873,8 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 starlette = [
-    {file = "starlette-0.13.6-py3-none-any.whl", hash = "sha256:bd2ffe5e37fb75d014728511f8e68ebf2c80b0fa3d04ca1479f4dc752ae31ac9"},
-    {file = "starlette-0.13.6.tar.gz", hash = "sha256:ebe8ee08d9be96a3c9f31b2cb2a24dbdf845247b745664bd8a3f9bd0c977fdbc"},
+    {file = "starlette-0.14.2-py3-none-any.whl", hash = "sha256:3c8e48e52736b3161e34c9f0e8153b4f32ec5d8995a3ee1d59410d92f75162ed"},
+    {file = "starlette-0.14.2.tar.gz", hash = "sha256:7d49f4a27f8742262ef1470608c59ddbc66baf37c148e938c7038e6bc7a998aa"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -21,11 +21,13 @@ def test_basic(ep, app, app_client):
                 'InternalError': {
                     'properties': {
                         'code': {
+                            'const': -32603,
                             'example': -32603,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Internal error',
                             'example': 'Internal error',
                             'title': 'Message',
                             'type': 'string',
@@ -37,6 +39,7 @@ def test_basic(ep, app, app_client):
                 'InvalidParams': {
                     'properties': {
                         'code': {
+                            'const': -32602,
                             'example': -32602,
                             'title': 'Code',
                             'type': 'integer',
@@ -45,6 +48,7 @@ def test_basic(ep, app, app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid params',
                             'example': 'Invalid params',
                             'title': 'Message',
                             'type': 'string',
@@ -56,6 +60,7 @@ def test_basic(ep, app, app_client):
                 'InvalidRequest': {
                     'properties': {
                         'code': {
+                            'const': -32600,
                             'example': -32600,
                             'title': 'Code',
                             'type': 'integer',
@@ -64,6 +69,7 @@ def test_basic(ep, app, app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid Request',
                             'example': 'Invalid Request',
                             'title': 'Message',
                             'type': 'string',
@@ -75,11 +81,13 @@ def test_basic(ep, app, app_client):
                 'MethodNotFound': {
                     'properties': {
                         'code': {
+                            'const': -32601,
                             'example': -32601,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Method not found',
                             'example': 'Method not found',
                             'title': 'Message',
                             'type': 'string',
@@ -91,11 +99,13 @@ def test_basic(ep, app, app_client):
                 'ParseError': {
                     'properties': {
                         'code': {
+                            'const': -32700,
                             'example': -32700,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Parse error',
                             'example': 'Parse error',
                             'title': 'Message',
                             'type': 'string',
@@ -162,6 +172,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -190,6 +201,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -218,6 +230,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -246,6 +259,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -274,6 +288,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -286,13 +301,11 @@ def test_basic(ep, app, app_client):
                 '_Params_probe_': {
                     'properties': {
                         'amount': {
-                            'example': 10,
                             'exclusiveMinimum': 5.0,
                             'title': 'Amount',
                             'type': 'integer',
                         },
                         'data': {
-                            'example': ['111', '222'],
                             'items': {
                                 'type': 'string',
                             },
@@ -320,6 +333,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -353,11 +367,13 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'probe',
                             'example': 'probe',
                             'title': 'Method',
                             'type': 'string',
@@ -386,6 +402,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -415,6 +432,7 @@ def test_basic(ep, app, app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',

--- a/tests/test_openapi_dependencies.py
+++ b/tests/test_openapi_dependencies.py
@@ -57,11 +57,13 @@ def test_basic(app_client):
                 'InternalError': {
                     'properties': {
                         'code': {
+                            'const': -32603,
                             'example': -32603,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Internal error',
                             'example': 'Internal error',
                             'title': 'Message',
                             'type': 'string',
@@ -73,6 +75,7 @@ def test_basic(app_client):
                 'InvalidParams': {
                     'properties': {
                         'code': {
+                            'const': -32602,
                             'example': -32602,
                             'title': 'Code',
                             'type': 'integer',
@@ -81,6 +84,7 @@ def test_basic(app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid params',
                             'example': 'Invalid params',
                             'title': 'Message',
                             'type': 'string',
@@ -92,6 +96,7 @@ def test_basic(app_client):
                 'InvalidRequest': {
                     'properties': {
                         'code': {
+                            'const': -32600,
                             'example': -32600,
                             'title': 'Code',
                             'type': 'integer',
@@ -100,6 +105,7 @@ def test_basic(app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid Request',
                             'example': 'Invalid Request',
                             'title': 'Message',
                             'type': 'string',
@@ -111,11 +117,13 @@ def test_basic(app_client):
                 'MethodNotFound': {
                     'properties': {
                         'code': {
+                            'const': -32601,
                             'example': -32601,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Method not found',
                             'example': 'Method not found',
                             'title': 'Message',
                             'type': 'string',
@@ -127,11 +135,13 @@ def test_basic(app_client):
                 'ParseError': {
                     'properties': {
                         'code': {
+                            'const': -32700,
                             'example': -32700,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Parse error',
                             'example': 'Parse error',
                             'title': 'Message',
                             'type': 'string',
@@ -198,6 +208,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -226,6 +237,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -254,6 +266,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -282,6 +295,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -310,6 +324,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -352,7 +367,6 @@ def test_basic(app_client):
                             'type': 'number',
                         },
                         'data': {
-                            'example': ['111', '222'],
                             'items': {
                                 'type': 'string',
                             },
@@ -373,11 +387,13 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'entrypoint',
                             'example': 'entrypoint',
                             'title': 'Method',
                             'type': 'string',
@@ -397,11 +413,13 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'probe2',
                             'example': 'probe2',
                             'title': 'Method',
                             'type': 'string',
@@ -428,11 +446,13 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'probe',
                             'example': 'probe',
                             'title': 'Method',
                             'type': 'string',
@@ -461,6 +481,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -483,6 +504,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -512,6 +534,7 @@ def test_basic(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -39,11 +39,13 @@ def test_openapi(app_client):
                 'InternalError': {
                     'properties': {
                         'code': {
+                            'const': -32603,
                             'example': -32603,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Internal error',
                             'example': 'Internal error',
                             'title': 'Message',
                             'type': 'string',
@@ -55,6 +57,7 @@ def test_openapi(app_client):
                 'InvalidParams': {
                     'properties': {
                         'code': {
+                            'const': -32602,
                             'example': -32602,
                             'title': 'Code',
                             'type': 'integer',
@@ -63,6 +66,7 @@ def test_openapi(app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid params',
                             'example': 'Invalid params',
                             'title': 'Message',
                             'type': 'string',
@@ -74,6 +78,7 @@ def test_openapi(app_client):
                 'InvalidRequest': {
                     'properties': {
                         'code': {
+                            'const': -32600,
                             'example': -32600,
                             'title': 'Code',
                             'type': 'integer',
@@ -82,6 +87,7 @@ def test_openapi(app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid Request',
                             'example': 'Invalid Request',
                             'title': 'Message',
                             'type': 'string',
@@ -93,11 +99,13 @@ def test_openapi(app_client):
                 'MethodNotFound': {
                     'properties': {
                         'code': {
+                            'const': -32601,
                             'example': -32601,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Method not found',
                             'example': 'Method not found',
                             'title': 'Message',
                             'type': 'string',
@@ -109,11 +117,13 @@ def test_openapi(app_client):
                 'ParseError': {
                     'properties': {
                         'code': {
+                            'const': -32700,
                             'example': -32700,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Parse error',
                             'example': 'Parse error',
                             'title': 'Message',
                             'type': 'string',
@@ -199,6 +209,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -227,6 +238,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -255,6 +267,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -283,6 +296,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -311,6 +325,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -336,6 +351,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -369,11 +385,13 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'probe',
                             'example': 'probe',
                             'title': 'Method',
                             'type': 'string',
@@ -402,6 +420,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -431,6 +450,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',

--- a/tests/test_shared_model.py
+++ b/tests/test_shared_model.py
@@ -82,11 +82,13 @@ def test_openapi(app_client):
                 'InternalError': {
                     'properties': {
                         'code': {
+                            'const': -32603,
                             'example': -32603,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Internal error',
                             'example': 'Internal error',
                             'title': 'Message',
                             'type': 'string',
@@ -98,6 +100,7 @@ def test_openapi(app_client):
                 'InvalidParams': {
                     'properties': {
                         'code': {
+                            'const': -32602,
                             'example': -32602,
                             'title': 'Code',
                             'type': 'integer',
@@ -106,6 +109,7 @@ def test_openapi(app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid params',
                             'example': 'Invalid params',
                             'title': 'Message',
                             'type': 'string',
@@ -117,6 +121,7 @@ def test_openapi(app_client):
                 'InvalidRequest': {
                     'properties': {
                         'code': {
+                            'const': -32600,
                             'example': -32600,
                             'title': 'Code',
                             'type': 'integer',
@@ -125,6 +130,7 @@ def test_openapi(app_client):
                             '$ref': '#/components/schemas/_ErrorData__Error_',
                         },
                         'message': {
+                            'const': 'Invalid Request',
                             'example': 'Invalid Request',
                             'title': 'Message',
                             'type': 'string',
@@ -136,11 +142,13 @@ def test_openapi(app_client):
                 'MethodNotFound': {
                     'properties': {
                         'code': {
+                            'const': -32601,
                             'example': -32601,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Method not found',
                             'example': 'Method not found',
                             'title': 'Message',
                             'type': 'string',
@@ -152,11 +160,13 @@ def test_openapi(app_client):
                 'ParseError': {
                     'properties': {
                         'code': {
+                            'const': -32700,
                             'example': -32700,
                             'title': 'Code',
                             'type': 'integer',
                         },
                         'message': {
+                            'const': 'Parse error',
                             'example': 'Parse error',
                             'title': 'Message',
                             'type': 'string',
@@ -223,6 +233,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -251,6 +262,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -279,6 +291,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -307,6 +320,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -335,6 +349,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -384,6 +399,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -410,11 +426,13 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'probe1',
                             'example': 'probe1',
                             'title': 'Method',
                             'type': 'string',
@@ -434,11 +452,13 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
                         },
                         'method': {
+                            'const': 'probe2',
                             'example': 'probe2',
                             'title': 'Method',
                             'type': 'string',
@@ -465,6 +485,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -487,6 +508,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',
@@ -510,6 +532,7 @@ def test_openapi(app_client):
                             'title': 'Id',
                         },
                         'jsonrpc': {
+                            'const': '2.0',
                             'example': '2.0',
                             'title': 'Jsonrpc',
                             'type': 'string',


### PR DESCRIPTION
closes #25 

This fixes the issues related to the updates of `openapi` doc generation in `fastapi` 0.64.0.

This allows us to bump `fastapi` to 0.66.0