### PR TITLE
Add bind_entrypoints option to reproduce FastApi's router feature

### DIFF
--- a/tests/test_merged_entrypoints.py
+++ b/tests/test_merged_entrypoints.py
@@ -1,0 +1,80 @@
+import pytest
+
+from fastapi_jsonrpc import API, Entrypoint
+
+
+@pytest.fixture
+def ep1(ep_path):
+    ep = Entrypoint(ep_path)
+
+    @ep.method()
+    def probe1() -> str:
+        return "probe1"
+
+    return ep
+
+
+@pytest.fixture
+def ep2(ep_path):
+    ep = Entrypoint(ep_path)
+
+    @ep.method()
+    def probe2() -> str:
+        return "probe2"
+
+    return ep
+
+
+@pytest.fixture
+def ep_path_v2():
+    return '/api/v2/jsonrpc'
+
+
+@pytest.fixture
+def ep3(ep_path_v2):
+    ep = Entrypoint(ep_path_v2)
+
+    @ep.method()
+    def probe() -> str:
+        return "probe3"
+
+    return ep
+
+
+@pytest.fixture
+def app(ep1, ep2, ep3):
+    app = API()
+    app.bind_entrypoint(ep1)
+    app.bind_entrypoint(ep2, add_to_existing_path=True)
+    app.bind_entrypoint(ep3)
+    return app
+
+
+def test_basic(json_request):
+    resp = json_request({
+        'id': 0,
+        'jsonrpc': '2.0',
+        'method': 'probe1',
+        'params': {},
+    })
+    assert resp == {'id': 0, 'jsonrpc': '2.0', 'result': 'probe1'}
+
+
+def test_method_from_second_ep(json_request):
+    resp = json_request({
+        'id': 0,
+        'jsonrpc': '2.0',
+        'method': 'probe2',
+        'params': {},
+    })
+    assert resp == {'id': 0, 'jsonrpc': '2.0', 'result': 'probe2'}
+
+
+def test_method_from_wrong_path_ep(json_request):
+    resp = json_request({
+        'id': 0,
+        'jsonrpc': '2.0',
+        'method': 'probe3',
+        'params': {},
+    })
+    assert resp == {'id': 0, 'jsonrpc': '2.0', 'error': {'code': -32601, 'message': 'Method not found'}}

--- a/tests/test_request_class.py
+++ b/tests/test_request_class.py
@@ -36,7 +36,7 @@ def test_custom_request_class(ep, json_request):
     assert resp == {'id': 0, 'jsonrpc': '2.0', 'result': 'probe'}
 
 
-def test_custom_request_class_unexpeted_type(ep, json_request):
+def test_custom_request_class_unexpected_type(ep, json_request):
     resp = json_request({
         'id': 0,
         'jsonrpc': '2.0',


### PR DESCRIPTION
closes #18 

Fastapi offers a router functionality detailed [here](https://fastapi.tiangolo.com/tutorial/bigger-applications/).
It can be really useful to split the methods into many files.

This PR adds an option to `bind_entrypoint` so that multiple Entrypoint with the same path can be merged.

Here is an example of how I would use this:

```python3
# main.py
from items import items_router
from products import products_router


app = jsonrpc.API()

app.bind_entrypoint(items_router)

app.bind_entrypoint(products_router, add_to_existing_path=True)

```

```python3
# items.py
import fastapi_jsonrpc as jsonrpc

items_router = jsonrpc.Entrypoint("/api")


@items_router.method()
def list_items() -> dict:
    return {"from": "list_items"}
```

```python3
# products.py
import fastapi_jsonrpc as jsonrpc

products_router = jsonrpc.Entrypoint("/api")


@products_router.method()
def list_products() -> dict:
    return {"from": "list_products"}
```

With this example, both `list_items` and `list_products` methods can be accessed from `/api`.

I have also added some tests for this feature.
