### PR TITLE
v2: support fastapi 0.106.0

### DIFF
--- a/.github/workflows/tests-latest-fastapi-pydantic.yml
+++ b/.github/workflows/tests-latest-fastapi-pydantic.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         fastapi-short: [default, latest]
         pydantic-short: [default, latest]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-jsonrpc"
-version = "2.7.2"
+version = "2.8.0"
 description = "JSON-RPC server based on fastapi"
 license = "MIT"
 authors = ["Sergey Magafurov <magafurov@tochka.com>"]
@@ -15,7 +15,7 @@ python = "^3.8"
 aiojobs = ">0.2.2"
 fastapi = [
     {version = ">0.55.0", python = "<3.11"},
-    {version = ">=0.86.0,<0.106.0", python = ">=3.11"},
+    {version = ">=0.106.0", python = ">=3.11"},
 ]
 pydantic = [
     {version = ">0.0.0", python = "<3.11"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ['json-rpc', 'asgi', 'swagger', 'openapi', 'fastapi', 'pydantic', 'st
 exclude = ["example1.py", "example2.py"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 aiojobs = ">0.2.2"
 fastapi = [
     {version = ">0.55.0", python = "<3.11"},


### PR DESCRIPTION
Fastapi introduce async exit stack for solving dependencies to suuport raise exception in yield-ed depends.
And totally separate background tasks from request. Now teardown (after yield) executed in scope of request

https://github.com/tiangolo/fastapi/commit/a4aa79e0b4cacc6b428d415d04d234a8c77af9d5


---
Same changes will be applied for v3
