### PR TITLE
feat(openrpc): describe each method's entrypoint servers

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -382,6 +382,24 @@ Declared errors, dependencies, headers, and return types all appear in the schem
 
 Tags, summaries, descriptions: pass to `@entrypoint.method(tags=..., summary=..., description=...)`.
 
+### OpenRPC method servers
+
+Every OpenRPC Method Object carries a `servers` list naming the HTTP endpoint that accepts it, so one document can describe several entrypoints:
+
+```json
+{"name": "echo", "servers": [{"name": "/api/v2/jsonrpc", "url": "/api/v2/jsonrpc"}]}
+```
+
+Rules:
+
+- No configured `servers` on `API()` — the method server is the entrypoint path itself, as a relative URL. Root `servers` stays `[]`.
+- Configured `servers` — each one is reused per method with the entrypoint path appended to its URL; `name`, `summary`, `description`, `variables` and `x-*` extensions are preserved, and a server without `name` gets its URL as the name.
+- `root_path` / `root_path_in_servers` behave as in FastAPI: the root path becomes the first server. A request arriving under a different `root_path` gets its own document that is not cached.
+- A malformed server entry (missing/non-string `url`, unknown non-`x-` field, variable without a `default`) raises at schema generation instead of emitting an invalid document.
+- The same method registered on several entrypoints merges into one Method Object with several servers, but only while the declarations are identical; differing contracts under one name raise `RuntimeError`, because OpenRPC requires unique method names.
+
+Caveat: this is schema fidelity, not routing. A consumer has to support `Method.servers` to use it; several OpenRPC tools read only the root `servers`.
+
 ## Testing
 
 The plugin `fastapi_jsonrpc.contrib.pytest_plugin` ships a complete harness: a JSON-RPC test client, a fixture that captures all error responses, a teardown validator that every captured error is declared in `@entrypoint.method(errors=[...])`, and a marker to opt out of validation for specific tests.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,7 +14,7 @@ app = jsonrpc.API(
 
 - `openrpc_url: str | None` — URL for the generated OpenRPC schema. Default: `/openrpc.json`. Pass `None` to turn it off.
 - `fastapi_jsonrpc_components_fine_names: bool` — controls the naming strategy for generated Pydantic components in the OpenAPI schema. Default: `True`. Set to `False` if the default names collide with your own schemas. See `tests/test_openapi.py` for exact behaviour.
-- Everything else is forwarded to `FastAPI`.
+- Everything else is forwarded to `FastAPI`. Among those, `servers`, `root_path` and `root_path_in_servers` also shape the OpenRPC document: they produce its root `servers`, and each method's `servers` is that same list with the entrypoint path appended to every URL. There is no OpenRPC-specific server parameter. See [OpenAPI & OpenRPC](../usage/openapi.md#which-endpoint-serves-a-method).
 
 ## Binding entrypoints
 

--- a/docs/usage/openapi.md
+++ b/docs/usage/openapi.md
@@ -29,6 +29,42 @@ The OpenRPC schema is generated from the same metadata as OpenAPI and is served 
 app = jsonrpc.API(openrpc_url=None)
 ```
 
+### Which endpoint serves a method
+
+One OpenRPC document can describe several entrypoints, so every method carries a `servers` list pointing at the HTTP endpoint that actually accepts it:
+
+```python
+app = jsonrpc.API()
+api_v1 = jsonrpc.Entrypoint('/api/v1/jsonrpc')
+api_v2 = jsonrpc.Entrypoint('/api/v2/jsonrpc')
+
+@api_v1.method()
+def legacy_echo(value: str = Body(...)) -> str:
+    return value
+
+@api_v2.method()
+def echo(value: str = Body(...)) -> str:
+    return value
+
+app.bind_entrypoint(api_v1)
+app.bind_entrypoint(api_v2)
+```
+
+```json
+{
+  "methods": [
+    {"name": "legacy_echo", "servers": [{"name": "/api/v1/jsonrpc", "url": "/api/v1/jsonrpc"}]},
+    {"name": "echo", "servers": [{"name": "/api/v2/jsonrpc", "url": "/api/v2/jsonrpc"}]}
+  ]
+}
+```
+
+This is schema fidelity, not client-side routing: a reader of the document can tell where to send each call, but consumers are free to ignore `Method.servers`, and several OpenRPC tools currently use only the root `servers`.
+
+When you configure `servers` on `API()`, each of them is reused for every method with the entrypoint path appended to its URL; `root_path` and `root_path_in_servers` behave as in FastAPI. Without any configured server the method server is the plain entrypoint path.
+
+Registering the same method on two entrypoints is allowed while both declarations are identical — the method appears once with both servers. OpenRPC requires method names to be unique, so two different contracts under one name raise a `RuntimeError` naming the method and both entrypoints instead of emitting an invalid document.
+
 ## Customising component names
 
 By default `fastapi-jsonrpc` gives its generated Pydantic models short, human-friendly names. If you need the raw FastAPI naming (e.g. to avoid collisions with your own components), set:

--- a/fastapi_jsonrpc/__init__.py
+++ b/fastapi_jsonrpc/__init__.py
@@ -35,6 +35,7 @@ from fastapi.routing import _DefaultLifespan  # noqa: WPS450  starlette's _Defau
 import fastapi.params
 import aiojobs
 import warnings
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
@@ -1486,6 +1487,96 @@ class Entrypoint(APIRouter):
         return decorator
 
 
+_OPENRPC_SERVER_FIELDS = {'name', 'url', 'summary', 'description', 'variables'}
+_OPENRPC_SERVER_VARIABLE_FIELDS = {'default', 'enum', 'description'}
+
+
+def _check_openrpc_fields(value: dict, allowed: set[str], location: str) -> None:
+    unknown = [key for key in value if key not in allowed and not key.startswith('x-')]
+    if unknown:
+        raise ValueError(f"{location} has unknown field {unknown[0]!r}")
+
+
+def _copy_openrpc_server_variables(variables: object, server_index: int) -> Dict[str, Any]:
+    if not isinstance(variables, dict):
+        raise TypeError(f"OpenRPC server {server_index} 'variables' must be a dict")
+
+    copied: Dict[str, Any] = {}
+    for variable_name, variable in variables.items():
+        location = f"OpenRPC server {server_index} variable {variable_name!r}"
+        if not isinstance(variable_name, str):
+            raise TypeError(f"{location} name must be a string")
+        if not isinstance(variable, dict):
+            raise TypeError(f"{location} must be a dict")
+        _check_openrpc_fields(variable, _OPENRPC_SERVER_VARIABLE_FIELDS, location)
+
+        default = variable.get('default')
+        if not isinstance(default, str):
+            raise ValueError(f"{location} 'default' must be a string")
+        if 'description' in variable and not isinstance(variable['description'], str):
+            raise TypeError(f"{location} 'description' must be a string")
+        if 'enum' in variable:
+            enum = variable['enum']
+            if not isinstance(enum, list) or not enum or not all(isinstance(item, str) for item in enum):
+                raise TypeError(f"{location} 'enum' must be a non-empty list of strings")
+
+        copied[variable_name] = copy.deepcopy(variable)
+    return copied
+
+
+def _copy_openrpc_server(server: object, index: int) -> Dict[str, Any]:
+    location = f"OpenRPC server {index}"
+    if not isinstance(server, dict):
+        raise TypeError(f"{location} must be a dict")
+    _check_openrpc_fields(server, _OPENRPC_SERVER_FIELDS, location)
+
+    url = server.get('url')
+    if not isinstance(url, str):
+        error_type = ValueError if url is None else TypeError
+        raise error_type(f"{location} 'url' must be a non-empty string")
+    if not url.strip():
+        raise ValueError(f"{location} 'url' must be a non-empty string")
+
+    parsed = urlsplit(url)
+    if parsed.scheme and not parsed.netloc:
+        raise ValueError(f"{location} 'url' must be hierarchical")
+
+    copied = copy.deepcopy(server)
+    name = copied.get('name')
+    if name is None:
+        copied['name'] = url
+    elif not isinstance(name, str):
+        raise TypeError(f"{location} 'name' must be a string")
+
+    for field_name in ('summary', 'description'):
+        if field_name in copied and not isinstance(copied[field_name], str):
+            raise TypeError(f"{location} {field_name!r} must be a string")
+    if 'variables' in copied:
+        copied['variables'] = _copy_openrpc_server_variables(copied['variables'], index)
+    return copied
+
+
+def _merge_openrpc_servers(existing: List[Dict[str, Any]], additions: Sequence[Dict[str, Any]]) -> None:
+    # Compared as whole objects: the same url with different metadata is a different
+    # server choice, so deduplicating by url alone would drop information
+    for addition in additions:
+        if addition not in existing:
+            existing.append(addition)
+
+
+def _append_openrpc_path(url: str, path: str) -> str:
+    parsed = urlsplit(url)
+    base_path = parsed.path.rstrip('/')
+    suffix = path.lstrip('/')
+    if base_path:
+        combined_path = f'{base_path}/{suffix}'
+    elif parsed.netloc or parsed.scheme or url.startswith('/'):
+        combined_path = f'/{suffix}'
+    else:
+        combined_path = suffix
+    return urlunsplit(parsed._replace(path=combined_path))
+
+
 class API(FastAPI):
     def __init__(
         self,
@@ -1650,8 +1741,28 @@ class API(FastAPI):
                     result['paths'][route.path][media_type]['responses'].pop('default', None)
         return result
 
+    def _get_openrpc_root_servers(self, root_path: str) -> List[Dict[str, Any]]:
+        if not isinstance(self.servers, list):
+            raise TypeError("API.servers must be a list")
+        servers = [
+            _copy_openrpc_server(server, index)
+            for index, server in enumerate(self.servers)
+        ]
+
+        root_path = root_path.rstrip('/')
+        if self.root_path_in_servers and root_path and not any(
+            server['url'] == root_path for server in servers
+        ):
+            servers.insert(0, {'name': root_path, 'url': root_path})
+        return servers
+
     def get_openrpc(self):
+        return self._get_openrpc(self.root_path)
+
+    def _get_openrpc(self, root_path):
+        root_servers = self._get_openrpc_root_servers(root_path)
         methods_spec = []
+        methods_by_name: Dict[str, Tuple[Dict[str, Any], Dict[str, Any], str]] = {}
         schemas_spec = {}
         errors_by_code = defaultdict(set)
         ref_template = '#/components/schemas/{model}'
@@ -1670,6 +1781,16 @@ class API(FastAPI):
 
             for error in route.errors:
                 errors_by_code[error.CODE].add(error)
+
+            entrypoint_path = route.entrypoint.entrypoint_route.path
+            if root_servers:
+                method_servers = []
+                for root_server in root_servers:
+                    method_server = copy.deepcopy(root_server)
+                    method_server['url'] = _append_openrpc_path(method_server['url'], entrypoint_path)
+                    method_servers.append(method_server)
+            else:
+                method_servers = [{'name': entrypoint_path, 'url': entrypoint_path}]
 
             method_spec = {
                 'name': route.name,
@@ -1701,9 +1822,24 @@ class API(FastAPI):
             if route.summary:
                 method_spec['summary'] = route.summary
 
-            methods_spec.append(method_spec)
             schemas_spec.update(params_schema.get('$defs', {}))
             schemas_spec.update(result_schema.get('$defs', {}))
+
+            declared = methods_by_name.get(route.name)
+            if declared is None:
+                emitted_spec = dict(method_spec, servers=method_servers)
+                methods_by_name[route.name] = (method_spec, emitted_spec, entrypoint_path)
+                methods_spec.append(emitted_spec)
+                continue
+
+            declared_spec, emitted_spec, declared_path = declared
+            if method_spec != declared_spec:
+                raise RuntimeError(
+                    f'OpenRPC requires a unique name per method, but {route.name!r} is declared '
+                    f'with different contracts by {declared_path} and {entrypoint_path}'
+                )
+
+            _merge_openrpc_servers(emitted_spec['servers'], method_servers)
 
         errors_spec = {}
         for code, errors in errors_by_code.items():
@@ -1743,7 +1879,7 @@ class API(FastAPI):
                 'version': self.version,
                 'title': self.title,
             },
-            'servers': self.servers,
+            'servers': root_servers,
             'methods': methods_spec,
             'components': {
                 'schemas': schemas_spec,
@@ -1760,6 +1896,17 @@ class API(FastAPI):
 
         return self.openrpc_schema
 
+    def _openrpc_for_root_path(self, root_path: str) -> Dict[str, Any]:
+        if not self.root_path_in_servers or root_path.rstrip('/') == self.root_path.rstrip('/'):
+            return self.openrpc()
+
+        # A proxy may serve the same app under several prefixes, so this document
+        # describes one request only and must stay out of the shared cache
+        schema = self._get_openrpc(root_path)
+        if self.fastapi_jsonrpc_components_fine_names and 'components' in schema:
+            self._restore_json_schema_fine_component_names(schema)
+        return schema
+
     def setup(self) -> None:
         super().setup()
 
@@ -1767,8 +1914,8 @@ class API(FastAPI):
             assert self.title, "A title must be provided for OpenRPC, e.g.: 'My API'"
             assert self.version, "A version must be provided for OpenRPC, e.g.: '2.1.0'"
 
-            async def openrpc(_: Request) -> JSONResponse:
-                return JSONResponse(self.openrpc())
+            async def openrpc(request: Request) -> JSONResponse:
+                return JSONResponse(self._openrpc_for_root_path(request.scope.get('root_path', '')))
 
             self.add_route(self.openrpc_url, openrpc, include_in_schema=False)
 

--- a/fastapi_jsonrpc/__init__.py
+++ b/fastapi_jsonrpc/__init__.py
@@ -1547,6 +1547,8 @@ def _copy_openrpc_server(server: object, index: int) -> Dict[str, Any]:
         copied['name'] = url
     elif not isinstance(name, str):
         raise TypeError(f"{location} 'name' must be a string")
+    elif not name.strip():
+        raise ValueError(f"{location} 'name' must be a non-empty string")
 
     for field_name in ('summary', 'description'):
         if field_name in copied and not isinstance(copied[field_name], str):

--- a/tests/test_openrpc.py
+++ b/tests/test_openrpc.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Optional
 
+import copy
+
 import pytest
 from starlette.testclient import TestClient
 
@@ -62,7 +64,13 @@ def test_basic(ep, app, app_client):
                 }
             },
             'tags': [],
-            'errors': []
+            'errors': [],
+            'servers': [
+                {
+                    'name': '/api/v1/jsonrpc',
+                    'url': '/api/v1/jsonrpc',
+                },
+            ],
         }
     ]
 
@@ -70,7 +78,7 @@ def test_basic(ep, app, app_client):
 def test_info_block(app, app_client):
     app.title = 'Test App'
     app.version = '1.2.3'
-    app.servers = [{'test': 'https://test.dev'}]
+    app.servers = [{'url': 'https://test.dev'}]
 
     resp = app_client.get('/openrpc.json')
 
@@ -80,7 +88,7 @@ def test_info_block(app, app_client):
             'version': app.version,
             'title': app.title,
         },
-        'servers': app.servers,
+        'servers': [{'name': 'https://test.dev', 'url': 'https://test.dev'}],
         'methods': [],
         'components': {
             'schemas': {},
@@ -353,3 +361,277 @@ def test_no_entrypoints__ok(fastapi_jsonrpc_components_fine_names):
     resp = app_client.get('/openrpc.json')
     resp.raise_for_status()
     assert resp.status_code == 200
+
+
+def _openrpc_with_server(server):
+    app = jsonrpc.API(servers=[server])
+    ep = jsonrpc.Entrypoint('/rpc')
+
+    @ep.method()
+    def server_probe() -> int:
+        return 1
+
+    app.bind_entrypoint(ep)
+    return app.get_openrpc()
+
+
+def test_method_server_preserves_configured_server():
+    server = {
+        'name': 'production',
+        'url': 'https://{region}.example.test/base/',
+        'summary': 'Production',
+        'description': 'Primary endpoint',
+        'variables': {
+            'region': {
+                'default': 'eu',
+                'enum': ['eu', 'us'],
+                'description': 'Deployment region',
+                'x-source': 'config',
+            },
+        },
+        'x-owner': {'team': 'payments'},
+    }
+    original = copy.deepcopy(server)
+
+    schema = _openrpc_with_server(server)
+
+    assert schema['servers'] == [server]
+    assert schema['methods'][0]['servers'] == [{
+        **server,
+        'url': 'https://{region}.example.test/base/rpc',
+    }]
+    assert server == original
+    assert schema['servers'][0] is not server
+    assert schema['servers'][0]['variables'] is not server['variables']
+
+
+def test_openrpc_server_name_defaults_to_url():
+    schema = _openrpc_with_server({
+        'url': 'https://example.test',
+        'description': 'Description is not a canonical name',
+    })
+
+    assert schema['servers'][0]['name'] == 'https://example.test'
+    assert schema['methods'][0]['servers'][0]['name'] == 'https://example.test'
+
+
+@pytest.mark.parametrize(
+    ('base_url', 'expected'),
+    [
+        ('https://api.test', 'https://api.test/rpc'),
+        ('https://api.test/', 'https://api.test/rpc'),
+        ('https://api.test/base/', 'https://api.test/base/rpc'),
+        ('https://api.test/base?q=1#docs', 'https://api.test/base/rpc?q=1#docs'),
+        ('//api.test/base', '//api.test/base/rpc'),
+        ('/base/', '/base/rpc'),
+        ('base/', 'base/rpc'),
+        ('https://{region}.test/{base}', 'https://{region}.test/{base}/rpc'),
+        ('https://api.test/a//b/./c%2Fd', 'https://api.test/a//b/./c%2Fd/rpc'),
+    ],
+)
+def test_method_server_url_composition(base_url, expected):
+    schema = _openrpc_with_server({'name': 'server', 'url': base_url})
+
+    assert schema['methods'][0]['servers'][0]['url'] == expected
+
+
+@pytest.mark.parametrize(
+    ('server', 'error', 'match'),
+    [
+        ('not-a-dict', TypeError, 'server 0'),
+        ({}, ValueError, "server 0.*url"),
+        ({'url': 123}, TypeError, "server 0.*url"),
+        ({'url': '   '}, ValueError, "server 0.*url"),
+        ({'url': 'https://example.test', 'name': 123}, TypeError, "server 0.*name"),
+        ({'url': 'https://example.test', 'unknown': True}, ValueError, "server 0.*unknown"),
+        ({'url': 'https://example.test', 'variables': []}, TypeError, "server 0.*variables"),
+        ({
+            'url': 'https://{region}.example.test',
+            'variables': {'region': {}},
+        }, ValueError, "server 0.*region.*default"),
+        ({'url': 'mailto:rpc@example.test'}, ValueError, "server 0.*url"),
+        ({'url': 'https:/broken'}, ValueError, "server 0.*url"),
+    ],
+)
+def test_invalid_openrpc_server_fails_fast(server, error, match):
+    app = jsonrpc.API(servers=[server])
+
+    with pytest.raises(error, match=match):
+        app.get_openrpc()
+
+
+def test_distinct_methods_report_own_entrypoint():
+    app = jsonrpc.API()
+    v1 = jsonrpc.Entrypoint('/api/v1/jsonrpc')
+    v2 = jsonrpc.Entrypoint('/api/v2/jsonrpc')
+
+    @v1.method()
+    def distinct_legacy_probe() -> int:
+        return 1
+
+    @v2.method()
+    def distinct_current_probe() -> int:
+        return 2
+
+    app.bind_entrypoint(v1)
+    app.bind_entrypoint(v2)
+    schema = app.get_openrpc()
+
+    servers_by_method = {method['name']: method['servers'] for method in schema['methods']}
+    assert servers_by_method == {
+        'distinct_legacy_probe': [{'name': '/api/v1/jsonrpc', 'url': '/api/v1/jsonrpc'}],
+        'distinct_current_probe': [{'name': '/api/v2/jsonrpc', 'url': '/api/v2/jsonrpc'}],
+    }
+
+
+def test_compatible_duplicate_method_merges_servers():
+    app = jsonrpc.API()
+    v1 = jsonrpc.Entrypoint('/api/v1/jsonrpc')
+    v2 = jsonrpc.Entrypoint('/api/v2/jsonrpc')
+
+    def merged_probe(value: int = Body(...)) -> int:
+        return value
+
+    v1.add_method_route(merged_probe)
+    v2.add_method_route(merged_probe)
+    app.bind_entrypoint(v1)
+    app.bind_entrypoint(v2)
+    schema = app.get_openrpc()
+
+    assert [method['name'] for method in schema['methods']] == ['merged_probe']
+    assert schema['methods'][0]['servers'] == [
+        {'name': '/api/v1/jsonrpc', 'url': '/api/v1/jsonrpc'},
+        {'name': '/api/v2/jsonrpc', 'url': '/api/v2/jsonrpc'},
+    ]
+
+
+def test_duplicate_method_does_not_duplicate_identical_server():
+    app = jsonrpc.API()
+    first = jsonrpc.Entrypoint('/rpc')
+    second = jsonrpc.Entrypoint('/rpc')
+
+    def same_endpoint_probe() -> int:
+        return 1
+
+    first.add_method_route(same_endpoint_probe)
+    second.add_method_route(same_endpoint_probe)
+    app.bind_entrypoint(first)
+    app.bind_entrypoint(second)
+    schema = app.get_openrpc()
+
+    assert schema['methods'][0]['servers'] == [{'name': '/rpc', 'url': '/rpc'}]
+
+
+def test_incompatible_duplicate_method_fails_fast():
+    app = jsonrpc.API()
+    v1 = jsonrpc.Entrypoint('/api/v1/jsonrpc')
+    v2 = jsonrpc.Entrypoint('/api/v2/jsonrpc')
+
+    # Same wire method name declared by different modules: component names stay
+    # distinct, so the clash only surfaces in the OpenRPC methods array
+    def probe_v1(value: int = Body(...)) -> int:
+        return value
+
+    def probe_v2(value: str = Body(...)) -> str:
+        return value
+
+    probe_v1.__module__ = 'api.v1'
+    probe_v2.__module__ = 'api.v2'
+    v1.add_method_route(probe_v1, name='incompatible_probe')
+    v2.add_method_route(probe_v2, name='incompatible_probe')
+    app.bind_entrypoint(v1)
+    app.bind_entrypoint(v2)
+
+    with pytest.raises(RuntimeError, match="'incompatible_probe'.*/api/v1/jsonrpc.*/api/v2/jsonrpc"):
+        app.get_openrpc()
+
+
+def _openrpc_app(**api_kwargs):
+    app = jsonrpc.API(**api_kwargs)
+    ep = jsonrpc.Entrypoint('/rpc')
+
+    @ep.method()
+    def root_path_probe() -> int:
+        return 1
+
+    app.bind_entrypoint(ep)
+    return app
+
+
+def test_root_path_becomes_first_openrpc_server():
+    schema = _openrpc_app(root_path='/proxy/').get_openrpc()
+
+    assert schema['servers'] == [{'name': '/proxy', 'url': '/proxy'}]
+    assert schema['methods'][0]['servers'] == [{'name': '/proxy', 'url': '/proxy/rpc'}]
+
+
+def test_root_path_precedes_configured_server():
+    schema = _openrpc_app(
+        root_path='/proxy',
+        servers=[{'url': 'https://api.test/base'}],
+    ).get_openrpc()
+
+    assert schema['servers'] == [
+        {'name': '/proxy', 'url': '/proxy'},
+        {'name': 'https://api.test/base', 'url': 'https://api.test/base'},
+    ]
+    assert schema['methods'][0]['servers'] == [
+        {'name': '/proxy', 'url': '/proxy/rpc'},
+        {'name': 'https://api.test/base', 'url': 'https://api.test/base/rpc'},
+    ]
+
+
+def test_configured_server_matching_root_path_is_not_duplicated():
+    schema = _openrpc_app(
+        root_path='/proxy',
+        servers=[{'name': 'behind-proxy', 'url': '/proxy', 'description': 'Terminated by nginx'}],
+    ).get_openrpc()
+
+    assert schema['servers'] == [
+        {'name': 'behind-proxy', 'url': '/proxy', 'description': 'Terminated by nginx'},
+    ]
+    assert schema['methods'][0]['servers'] == [
+        {'name': 'behind-proxy', 'url': '/proxy/rpc', 'description': 'Terminated by nginx'},
+    ]
+
+
+def test_disabled_root_path_in_servers_keeps_configured_servers():
+    schema = _openrpc_app(
+        root_path='/proxy',
+        root_path_in_servers=False,
+        servers=[{'url': 'https://api.test'}],
+    ).get_openrpc()
+
+    assert schema['servers'] == [{'name': 'https://api.test', 'url': 'https://api.test'}]
+    assert schema['methods'][0]['servers'] == [
+        {'name': 'https://api.test', 'url': 'https://api.test/rpc'},
+    ]
+
+
+def test_disabled_root_path_in_servers_without_configured_servers():
+    schema = _openrpc_app(root_path='/proxy', root_path_in_servers=False).get_openrpc()
+
+    assert schema['servers'] == []
+    assert schema['methods'][0]['servers'] == [{'name': '/rpc', 'url': '/rpc'}]
+
+
+def test_request_root_path_does_not_pollute_cached_schema():
+    app = _openrpc_app()
+
+    proxied = TestClient(app, root_path='/proxy').get('/openrpc.json').json()
+    direct = TestClient(app).get('/openrpc.json').json()
+
+    assert proxied['servers'] == [{'name': '/proxy', 'url': '/proxy'}]
+    assert proxied['methods'][0]['servers'] == [{'name': '/proxy', 'url': '/proxy/rpc'}]
+    assert direct['servers'] == []
+    assert direct['methods'][0]['servers'] == [{'name': '/rpc', 'url': '/rpc'}]
+    assert app.openrpc_schema['servers'] == []
+    assert proxied['components'] == direct['components']
+
+
+def test_request_root_path_matching_configured_root_path_uses_cache():
+    app = _openrpc_app(root_path='/proxy')
+
+    schema = TestClient(app, root_path='/proxy').get('/openrpc.json').json()
+
+    assert schema == app.openrpc_schema

--- a/tests/test_openrpc.py
+++ b/tests/test_openrpc.py
@@ -443,6 +443,7 @@ def test_method_server_url_composition(base_url, expected):
         ({'url': 123}, TypeError, "server 0.*url"),
         ({'url': '   '}, ValueError, "server 0.*url"),
         ({'url': 'https://example.test', 'name': 123}, TypeError, "server 0.*name"),
+        ({'url': 'https://example.test', 'name': '   '}, ValueError, "server 0.*name"),
         ({'url': 'https://example.test', 'unknown': True}, ValueError, "server 0.*unknown"),
         ({'url': 'https://example.test', 'variables': []}, TypeError, "server 0.*variables"),
         ({


### PR DESCRIPTION
Supersedes #90. Thanks to @maintainer64 for identifying the gap and for the original patch — the scenario is theirs; the implementation here is written from scratch against current `master`.

## Problem

An OpenRPC document can describe several JSON-RPC entrypoints, but until now every Method Object looked the same: only the root `servers` said where to send a call. A reader of `/openrpc.json` could not tell that `/api/v1/jsonrpc` and `/api/v2/jsonrpc` serve different methods.

## What changed

Each Method Object now carries `servers` naming the entrypoint that accepts it:

```json
{"name": "echo", "servers": [{"name": "/api/v2/jsonrpc", "url": "/api/v2/jsonrpc"}]}
```

- **Configured `API(servers=...)`** are reused per method with the entrypoint path appended to their URL. `name`, `summary`, `description`, `variables` and `x-*` extensions are preserved; a server without `name` gets its URL as the name, since OpenRPC requires one.
- **Without configured servers** the method server is the relative entrypoint path. No `http://localhost` is invented — an empty root `servers` stays empty, which the spec already defines on the consumer side.
- **`root_path` / `root_path_in_servers`** keep their FastAPI meaning: the root path becomes the first server. A request arriving under a *different* `root_path` gets its own document that is never written to the shared `openrpc_schema` cache.
- **Root `servers`** is emitted in the same validated, adapted form instead of the raw FastAPI value.

### Unique method names

OpenRPC requires `Method.name` to be unique. The same method registered on several entrypoints merges into a single Method Object with several servers while the declarations are identical. Two *different* contracts under one name now raise a `RuntimeError` naming the method and both entrypoints, instead of emitting a document with duplicate names.

### Fail-fast on malformed configuration

A missing or non-string `url`, an unknown non-`x-` field, an opaque URI (`mailto:`, `urn:`), or a variable without a string `default` raises at schema generation rather than silently producing an invalid document.

## How this differs from #90

| | #90 | here |
|---|---|---|
| No configured server | hardcodes `http://localhost` | relative entrypoint path |
| URL composition | string concatenation | `urlsplit`/`urlunsplit` on the path component only |
| Server metadata | dropped (`name`/`url` only) | `summary`, `description`, `variables`, `x-*` preserved |
| Duplicate `Method.name` | left in the document | merged when identical, raises when not |
| `root_path` | not handled | handled, request-aware, cache-isolated |

## Caveat, stated deliberately

This is **schema fidelity, not client-side routing**. A consumer has to support `Method.servers` to benefit; several OpenRPC tools currently read only the root `servers`. The docs say so rather than promising automatic endpoint selection.

## Compatibility

`servers` is an inherited FastAPI parameter, so the root document is now validated where it previously passed through unchecked. Every `servers` example from FastAPI's own documentation — multi-environment, relative `/api/v1`, bare `/`, URI templates with `{username}`/`{port}`/`{basePath}` variables, `x-` extensions — was verified to pass unchanged.

## Verification

- 41 tests in `tests/test_openrpc.py` (was 9), 205 total, green on Python 3.14 and 3.10.
- Green on latest FastAPI 0.141.1 / Pydantic 2.13.5.
- `mypy` clean; `openrpc: '1.2.6'` and `uv.lock` unchanged.
- Request isolation checked empirically across interleaved root paths `/a`, `/b`, `''`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)