### PR TITLE
fix(openrpc): type-check the OpenRPC generator and close what it exposed

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -14,7 +14,7 @@ class NotEnoughMoney(jsonrpc.BaseError):
 
 ## Class attributes
 
-- **`CODE: int`** — JSON-RPC error code. Required.
+- **`CODE: int`** — JSON-RPC error code. Required: an error class declared in `@entrypoint.method(errors=[...])` without one raises when the OpenRPC schema is generated, since nothing could reference it.
 - **`MESSAGE: str`** — human-readable message. Required.
 - **`DataModel: type[BaseModel] | None`** — optional Pydantic model for the `error.data` payload. When set, the value passed to `raise MyError(data=...)` is validated against it.
 - **`ErrorModel: type[BaseModel] | None`** — optional model for entries inside `error.data.errors` (used by `InvalidRequest` and `InvalidParams` to describe individual validation issues).

--- a/fastapi_jsonrpc/__init__.py
+++ b/fastapi_jsonrpc/__init__.py
@@ -877,7 +877,9 @@ class MethodRoute(APIRoute):
         self.app = request_response(self.handle_http_request)
         self.request_class = request_class
         self.result_model = result_model
-        self.params_model = _Request.model_fields['params'].annotation
+        params_model = _Request.model_fields['params'].annotation
+        assert params_model is not None, f"method {name!r} has no params annotation"
+        self.params_model: Type[Any] = params_model
         self.errors = errors or []
 
     def __hash__(self):
@@ -1761,7 +1763,7 @@ class API(FastAPI):
     def get_openrpc(self):
         return self._get_openrpc(self.root_path)
 
-    def _get_openrpc(self, root_path):
+    def _get_openrpc(self, root_path: str) -> Dict[str, Any]:
         root_servers = self._get_openrpc_root_servers(root_path)
         methods_spec = []
         methods_by_name: Dict[str, Tuple[Dict[str, Any], Dict[str, Any], str]] = {}
@@ -1775,14 +1777,18 @@ class API(FastAPI):
 
             params_schema = route.params_model.model_json_schema(ref_template=ref_template)
 
-            if isinstance(route.result_model, BaseModel):
-                result_schema = route.result_model.model_json_schema(ref_template=ref_template)
-            else:
-                result_model = create_model(f'{route.name}_Result', result=(route.result_model or Any, ...))
-                result_schema = result_model.model_json_schema(ref_template=ref_template)
+            result_model = create_model(f'{route.name}_Result', result=(route.result_model or Any, ...))
+            result_schema = result_model.model_json_schema(ref_template=ref_template)
 
+            error_codes = set()
             for error in route.errors:
+                if error.CODE is None:
+                    raise RuntimeError(
+                        f'{error.__name__} is declared on method {route.name!r} but has no CODE, '
+                        f'so nothing can reference it in the schema'
+                    )
                 errors_by_code[error.CODE].add(error)
+                error_codes.add(error.CODE)
 
             entrypoint_path = route.entrypoint.entrypoint_route.path
             if root_servers:
@@ -1794,7 +1800,7 @@ class API(FastAPI):
             else:
                 method_servers = [{'name': entrypoint_path, 'url': entrypoint_path}]
 
-            method_spec = {
+            method_spec: Dict[str, Any] = {
                 'name': route.name,
                 'params': [
                     {
@@ -1818,7 +1824,7 @@ class API(FastAPI):
                     {
                         '$ref': f'#/components/errors/{code}',
                     }
-                    for code in sorted({error.CODE for error in route.errors})
+                    for code in sorted(error_codes)
                 ],
             }
             if route.summary:

--- a/tests/test_openrpc.py
+++ b/tests/test_openrpc.py
@@ -309,6 +309,36 @@ def test_errors_merging(ep, app, app_client):
     }
 
 
+def test_error_without_code_fails_fast(ep, app):
+    class ForgotCode(jsonrpc.BaseError):
+        MESSAGE = 'No code was declared'
+
+    @ep.method(errors=[ForgotCode])
+    def my_method__with_codeless_error() -> None:
+        return None
+
+    app.bind_entrypoint(ep)
+
+    with pytest.raises(RuntimeError, match="ForgotCode.*my_method__with_codeless_error.*CODE"):
+        app.get_openrpc()
+
+
+def test_model_return_type_is_referenced(ep, app):
+    class Wrapped(BaseModel):
+        x: int
+
+    @ep.method()
+    def my_method__returning_model() -> Wrapped:
+        return Wrapped(x=1)
+
+    app.bind_entrypoint(ep)
+
+    assert app.get_openrpc()['methods'][0]['result'] == {
+        'name': 'my_method__returning_model_Result',
+        'schema': {'$ref': '#/components/schemas/Wrapped'},
+    }
+
+
 def test_type_hints(ep, app, app_client):
     Input = List[str]
     Output = Dict[str, List[List[float]]]


### PR DESCRIPTION
Follow-up to #110. That PR extracted `_get_openrpc` but deliberately left it unannotated, so the body kept the same type-check status it had as `get_openrpc` — untyped, therefore never inspected by mypy. Annotating it here surfaced three latent problems; each one is fixed rather than silenced, and no `# type: ignore` was added.

### 1. A dead branch that would have crashed if reached

```python
if isinstance(route.result_model, BaseModel):
    result_schema = route.result_model.model_json_schema(...)
```

`result_model` holds the return annotation, i.e. a **class**, and a class is not an instance of `BaseModel` — measured: `isinstance(Out, BaseModel)` is `False`, `issubclass(Out, BaseModel)` is `True`. So this branch never ran. Had it run, the very next statement would have raised `KeyError`, because it reads `result_schema['properties']['result']` while an instance schema carries the model's own fields (`['x']`, not `['result']`).

Removed. The remaining path already produces the right thing for a model return type — `{'name': 'probe_Result', 'schema': {'$ref': '#/components/schemas/Out'}}` — and a new test locks that.

### 2. An error class without `CODE` produced an invalid document

`docs/reference/errors.md` already says `CODE: int` is **required**, but nothing enforced it. Measured on `master`: such a class is accepted at registration and yields

```json
{"$ref": "#/components/errors/None"}
{"None": {"code": null, "message": "..."}}
```

Now it raises at schema generation, naming the class and the method. This only fires on configurations that were already emitting a broken schema and returning `"code": null` over the wire — a JSON-RPC protocol violation. Same defect class #110 closed for server objects.

### 3. `params_model` typed optional by pydantic

It comes from `FieldInfo.annotation`, which pydantic types as `type[Any] | None`, while both construction paths in `make_request_model` always set it. The invariant is now asserted where it is established, in the project's existing `assert` idiom, instead of being papered over at the call site.

## Not touched

`BaseError.CODE` keeps its `Optional[int] = None` declaration — narrowing it would be a contract change on a public base class that user code subclasses.

## Verification

- 208 tests (two new), green on Python 3.14 and 3.10, and on latest FastAPI 0.141.1 / Pydantic 2.13.5.
- `mypy` clean, and now genuinely checking the generator body rather than skipping it.
- Docs build; `uv.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)